### PR TITLE
update(feat): countdown format (m,s,h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ author: Lorem Ipsum
 
 `type`: countdown
 
-`date`: Must be in the format `YYYY-MM-DD HH:MM:SS`
+`date`: Accepts either the standard format `YYYY-MM-DD HH:MM:SS` or relative time expressions such as `+Ns` (seconds), `+Nm` (minutes), `+Nh` (hours), and `+Nd` (days), where `N` is a numerical value.
 
 `to`: Description of the countdown (optional)
 

--- a/src/Countdown/index.tsx
+++ b/src/Countdown/index.tsx
@@ -11,7 +11,33 @@ const Countdown = ({ settings: { date, to } }: CountdownProps) => {
 	const [invalidDate, setInvalidDate] = useState<string | null>(null);
 
 	useEffect(() => {
-		const endTime = moment(`${date}`);
+
+		// Check if date is in the format +[number][s/m/h]
+		const dateRegex = /^(\+)(\d+)([smh])$/;
+		const dateMatch = date.match(dateRegex);
+		var endTime;
+
+		if (dateMatch) {
+			const [, operator, value, unit] = dateMatch;
+
+			const currentTime = moment();
+			endTime = currentTime.clone();
+
+			switch (unit) {
+				case "s":
+					endTime.add(parseInt(value), "seconds");
+					break;
+				case "m":
+					endTime.add(parseInt(value), "minutes");
+					break;
+				case "h":
+					endTime.add(parseInt(value), "hours");
+					break;
+			}
+
+		} else {
+			endTime = moment(`${date}`);
+		}
 
 		if (!endTime.isValid()) {
 			setInvalidDate("Invalid Date");


### PR DESCRIPTION
It seemed to me that the countdown widget could be improved by adding the format `+n[s/m/h]`. For example, to create a 5 minute counter we would use:

~~~markdown
```widgets
type: countdown
date: +5m
to: Happy!
```
~~~

P.S. Very cool plugin.