### PR TITLE
add support for +Nd on Countdown widget

### DIFF
--- a/src/Countdown/index.tsx
+++ b/src/Countdown/index.tsx
@@ -13,8 +13,8 @@ const Countdown = ({ settings: { date, to } }: CountdownProps) => {
 	const [invalidDate, setInvalidDate] = useState<string | null>(null);
 
 	useEffect(() => {
-		// Check if date is in the format +[number][s/m/h]
-		const dateRegex = /^(\+)(\d+)([smh])$/;
+		// Check if date is in the format +[number][s/m/h/d]
+		const dateRegex = /^(\+)(\d+)([smhd])$/;
 		const dateMatch = date.match(dateRegex);
 		let endTime: Moment;
 
@@ -33,6 +33,9 @@ const Countdown = ({ settings: { date, to } }: CountdownProps) => {
 					break;
 				case "h":
 					endTime.add(parseInt(value), "hours");
+					break;
+				case "d":
+					endTime.add(parseInt(value), "days");
 					break;
 			}
 		} else {


### PR DESCRIPTION
This adds support for adding +Nd as an option to the date of the Countdown widget

```
```widgets
type: countdown
date: +10d
to:
``
```